### PR TITLE
Add explicit memory sizing for lab 03

### DIFF
--- a/03-push/web-app/manifest.yml
+++ b/03-push/web-app/manifest.yml
@@ -1,3 +1,4 @@
 applications:
 - name: web-app
   random-route: true
+  memory: 512M

--- a/03-push/worker-app/manifest.yml
+++ b/03-push/worker-app/manifest.yml
@@ -3,3 +3,4 @@ applications:
   command: ruby periodic_logger.rb
   no-route: true
   health-check-type: none
+  memory: 64M


### PR DESCRIPTION
I had some other apps already in my account, which took me over the
2GB RAM quota on the free PCF tier.

Being explicit about the memory requirements for these apps means
that attendees are less likely to bump up against this constraint.
